### PR TITLE
fix: Add missing / separator in page API URL

### DIFF
--- a/utils/page.go
+++ b/utils/page.go
@@ -21,7 +21,7 @@ type Page struct {
 
 func getNotionPage(notionAPIKey, pageID string) (*Page, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", baseURL+"pages/"+pageID, nil)
+	req, err := http.NewRequest("GET", baseURL+"/pages/"+pageID, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Corrected the URL construction in the `getNotionPage` function to include the missing '/' separator.
- Ensures the API URL is correctly formed as `https://api.notion.com/v1/pages/<id>`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/page.go`: Fixed the URL construction in the `getNotionPage` function by adding a missing '/' between `baseURL` and `pages` path segment, ensuring the URL is correctly formatted.
</details>

___
## User Description:
## Summary
- The `getNotionPage` function in `utils/page.go` constructs the URL as `baseURL+"pages/"+pageID`, which produces `https://api.notion.com/v1pages/<id>` — missing the `/` between the base path and `pages`.
- Fixed to `baseURL+"/pages/"+pageID` so the URL is correctly formed as `https://api.notion.com/v1/pages/<id>`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
