### PR TITLE
fix: Register text flag on addCmd instead of checkCmd

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,5 +28,5 @@ var addCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(addCmd)
-	checkCmd.Flags().String("text", "", "Text for the new task")
+	addCmd.Flags().String("text", "", "Text for the new task")
 }


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Corrected the registration of the `--text` flag in the `init()` function of `cmd/add.go`.
- Previously, the flag was incorrectly registered with `checkCmd` instead of `addCmd`.
- Ensures that the `--text` flag is now available for the `add` command as intended.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cmd/add.go`: The `init()` function was modified to register the `--text` flag with `addCmd` instead of `checkCmd`, correcting the command association for the flag.
</details>

___
## User Description:
## Summary
- In `cmd/add.go`, the `init()` function registers the `--text` flag on `checkCmd` instead of `addCmd`, attaching it to the wrong command.
- Fixed to register on `addCmd` so the flag is available on the `add` command where it belongs.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
