### PR TITLE
fix: Add pagination support to GetBlocks and GetBlockID

### DIFF
--- a/utils/block.go
+++ b/utils/block.go
@@ -124,33 +124,15 @@ type BlockList struct {
 }
 
 func GetBlocks(notionAPIKey, pageID string) ([]Block, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", baseURL+"/blocks/"+pageID+"/children", nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %v", err)
-	}
-
-	req.Header.Add("accept", "application/json")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var blockList BlockList
-
-	err = json.NewDecoder(resp.Body).Decode(&blockList)
+	allBlocks, err := GetAllBlocks(notionAPIKey, pageID, "to_do")
 	if err != nil {
 		return nil, err
 	}
 
 	var blocks []Block
-	for _, result := range blockList.Results {
-		if result.Object == "block" && result.ToDo != nil && len(result.ToDo.RichText) > 0 {
-			blocks = append(blocks, result)
+	for _, block := range allBlocks {
+		if block.ToDo != nil && len(block.ToDo.RichText) > 0 {
+			blocks = append(blocks, block)
 		}
 	}
 	return blocks, nil
@@ -235,34 +217,17 @@ func GetBlockID(notionAPIKey, pageID string, order int) (string, error) {
 	if order < 1 {
 		return "", fmt.Errorf("order must be greater than 0")
 	}
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", baseURL+"/blocks/"+pageID+"/children", nil)
-	if err != nil {
-		return "", fmt.Errorf("error creating request: %v", err)
-	}
 
-	req.Header.Add("accept", "application/json")
-	req.Header.Add("Notion-Version", "2022-06-28")
-	req.Header.Set("Authorization", "Bearer "+notionAPIKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	var blockList BlockList
-	err = json.NewDecoder(resp.Body).Decode(&blockList)
+	allBlocks, err := GetAllBlocks(notionAPIKey, pageID, "")
 	if err != nil {
 		return "", err
 	}
 
-	if order > len(blockList.Results) {
+	if order > len(allBlocks) {
 		return "", fmt.Errorf("order number exceeds the number of blocks")
 	}
 
-	return blockList.Results[order-1].ID, nil
-
+	return allBlocks[order-1].ID, nil
 }
 
 func MarkToDoBlockChecked(notionAPIKey, pageID string, order int) error {


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Refactored `GetBlocks()` and `GetBlockID()` to support pagination by using `GetAllBlocks()` internally.
- Removed duplicated HTTP request logic in both functions.
- Ensured that both functions can handle pages with more than 100 blocks.
- Simplified the codebase by reducing redundant code.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/block.go`: - Refactored `GetBlocks()` to call `GetAllBlocks()` for fetching blocks, removing the direct HTTP request logic and decoding of the response.
- Updated the logic to filter and append blocks based on the presence of `ToDo` items.
- Refactored `GetBlockID()` to also use `GetAllBlocks()`, eliminating the need for direct HTTP requests and response decoding.
- Simplified the logic to check if the requested order exceeds the number of available blocks.
</details>

___
## User Description:
## Summary
- `GetBlocks()` and `GetBlockID()` only fetched the first page of results (max 100 blocks) from the Notion API, while `GetAllBlocks()` already correctly implements cursor-based pagination.
- Refactored both functions to reuse `GetAllBlocks()` internally, eliminating duplicated HTTP logic and ensuring they handle pages with more than 100 blocks correctly.
- Net reduction of 35 lines by removing duplicated API call code.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 11 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
