### PR TITLE
fix: Remove unused global blocks variable

### DIFF
--- a/utils/block.go
+++ b/utils/block.go
@@ -16,8 +16,6 @@ import (
 
 var baseURL = "https://api.notion.com/v1"
 
-var blocks []Block
-
 // BlockTypeInfo contains display information for a block type
 type BlockTypeInfo struct {
 	Icon  string


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Removed the unused package-level variable `blocks` from `utils/block.go`.
- This variable was declared but never used, as all functions in the file use locally scoped variables instead.
- The change helps in cleaning up the code by removing unnecessary declarations.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/block.go`: Removed the declaration of the unused global variable `blocks []Block`.
</details>

___
## User Description:
## Summary
- The package-level `var blocks []Block` in `utils/block.go` is declared but never referenced — all functions use locally scoped variables instead.
- Removed the unused declaration to clean up the code.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
