### PR TITLE
fix: Replace deprecated ioutil with io

### DIFF
--- a/utils/block.go
+++ b/utils/block.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"time"
@@ -224,7 +224,7 @@ func AddNewToDoItem(notionAPIKey, pageID, text string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(bodyBytes))
 	}
 
@@ -597,7 +597,7 @@ func AddBlock(notionAPIKey, pageID, blockType, text string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(bodyBytes))
 	}
 
@@ -635,7 +635,7 @@ func DeleteBlock(notionAPIKey, pageID string, order int) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code: %d, message: %s", resp.StatusCode, string(bodyBytes))
 	}
 

--- a/utils/page.go
+++ b/utils/page.go
@@ -6,7 +6,7 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -36,7 +36,7 @@ func getNotionPage(notionAPIKey, pageID string) (*Page, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
- Replaced deprecated `ioutil.ReadAll` with `io.ReadAll` in the `utils` package.
- Updated 3 occurrences in `utils/block.go`.
- Updated 1 occurrence in `utils/page.go`.
- Ensures compatibility with Go 1.16 and later versions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `utils/block.go`: - Replaced `ioutil.ReadAll` with `io.ReadAll` in three functions: `AddNewToDoItem`, `AddBlock`, and `DeleteBlock`.
- This change ensures that the code is using the non-deprecated method for reading from `resp.Body`.
- `utils/page.go`: - Replaced `ioutil.ReadAll` with `io.ReadAll` in the `getNotionPage` function.
- This update aligns with the deprecation of `ioutil.ReadAll` and uses the recommended `io.ReadAll` method.
</details>

___
## User Description:
## Summary
- `ioutil.ReadAll` has been deprecated since Go 1.16 in favor of `io.ReadAll`.
- Updated all usages in `utils/block.go` (3 occurrences) and `utils/page.go` (1 occurrence).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
