### PR TITLE
chore: Upgrade Go version from 1.19 to 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       
       - name: Build
         run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module notioncli
 
-go 1.19
+go 1.22
 
 require (
 	github.com/fatih/color v1.15.0


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Upgraded the Go version from 1.19 to 1.22 due to the end-of-life status of Go 1.19.
- Updated the `go.mod` file to reflect the new Go version.
- Modified the CI workflow configuration to use Go 1.22.
- Ensured compatibility by running build and test commands successfully.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/test.yml`: Updated the Go version in the CI workflow from 1.21 to 1.22 to ensure the tests run with the latest stable Go version.
- `go.mod`: Changed the Go version from 1.19 to 1.22 to align with the latest stable release and maintain security and support.
</details>

___
## User Description:
## Summary
- Go 1.19 reached end-of-life in August 2023 and no longer receives security patches.
- Bumped `go.mod` from 1.19 to 1.22.
- Updated CI workflow (`test.yml`) from 1.21 to 1.22 to match.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go mod tidy` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
